### PR TITLE
Fix bundle install error due to invalid homepage

### DIFF
--- a/lita-identity-manager.gemspec
+++ b/lita-identity-manager.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |spec|
   spec.email         = ["sebastian.geiger@gmail.com"]
   spec.description   = "A lita plugin that lets you manage identities"
   spec.summary       = "With this plugin you can link users to their identity on external services"
-  spec.homepage      = "TODO: Add a homepage"
-  spec.license       = "TODO: Add a license"
+  spec.homepage      = "https://github.com/sebastiangeiger/lita-identity-manager"
+  spec.license       = "ISC"
   spec.metadata      = { "lita_plugin_type" => "handler" }
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
```
> bundle install
Fetching https://github.com/sebastiangeiger/lita-identity-manager.git
You have one or more invalid gemspecs that need to be fixed.
The gemspec at
~/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/lita-identity-manager-0ce0d2e45ea6/lita-identity-manager.gemspec
is not valid. Please fix this gemspec.
The validation error was '"TODO: Add a homepage" is not a valid HTTP URI'
```

And in case it barfs on license the way that NPM likes to, pick one for that, too.